### PR TITLE
Don't inject the container in services.

### DIFF
--- a/EventListener/DefaultMenuListener.php
+++ b/EventListener/DefaultMenuListener.php
@@ -2,37 +2,14 @@
 
 namespace SumoCoders\FrameworkCoreBundle\EventListener;
 
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Security\Core\SecurityContext;
 
-class DefaultMenuListener implements ContainerAwareInterface
+class DefaultMenuListener
 {
-    /**
-     * @var ContainerInterface
-     */
-    private $container;
-
     /**
      * @var SecurityContext
      */
     private $securityContext;
-
-    /**
-     * @param ContainerInterface $container
-     */
-    public function __construct(ContainerInterface $container)
-    {
-        $this->setContainer($container);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setContainer(ContainerInterface $container = null)
-    {
-        $this->container = $container;
-    }
 
     /**
      * @return \Symfony\Component\Security\Core\SecurityContext

--- a/Resources/doc/menu.md
+++ b/Resources/doc/menu.md
@@ -53,8 +53,6 @@ Add the configuration
 services:
   framework_example.listener.menu_listener:
     class: SumoCoders\FrameworkExampleBundle\EventListener\MenuListener
-    arguments:
-      - @service_container
     calls:
       - [setSecurityContext, ["@security.context"]]
     tags:

--- a/Tests/EventListener/DefaultMenuListenerTest.php
+++ b/Tests/EventListener/DefaultMenuListenerTest.php
@@ -16,19 +16,7 @@ class DefaultMenuListenerTest extends \PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        $this->defaultMenuListener = new DefaultMenuListener(
-            $this->getContainer()
-        );
-    }
-
-    /**
-     * @return \PHPUnit_Framework_MockObject_MockObject
-     */
-    protected function getContainer()
-    {
-        $container = $this->getMock('\Symfony\Component\DependencyInjection\ContainerInterface');
-
-        return $container;
+        $this->defaultMenuListener = new DefaultMenuListener();
     }
 
     /**


### PR DESCRIPTION
It's a validation on good code design to inject a service container into a service. If you need certain objects in your service, you don't want to fetch them from the container. The objects itself (f.e. doctrine) should be injected in your service instead of the container itself.