### PR TITLE
Fix the user menu so it works with basic symfony security user authentication

### DIFF
--- a/Resources/views/base.html.twig
+++ b/Resources/views/base.html.twig
@@ -78,13 +78,21 @@
                   {% else %}
                     <i class="fas fa-user-circle mr-md-1"></i>
                   {% endif %}
-                  <span class="d-none d-md-block mr-md-1">{{ msgphp_user.current.name }}</span>
+                  <span class="d-none d-md-block mr-md-1">
+                    {% if msgphp_user is defined %}
+                      {{ msgphp_user.current.name }}
+                    {% else %}
+                      {{ app.user.username }}
+                    {% endif %}
+                  </span>
                   <span class="fas fa-chevron-right fa-w-16 d-none d-md-block"></span>
                 </button>
                 <ul class="dropdown-menu" role="menu">
-                  {% block userNavigation %}
-                  <li><a href="{{ path('profile', { 'user': msgphp_user.current.id }) }}">{{ 'account'|trans|capitalize }}</a></li>
-                  {% endblock %}
+                  {% if msgphp_user is defined %}
+                    {% block userNavigation %}
+                      <li><a href="{{ path('profile', { 'user': msgphp_user.current.id }) }}">{{ 'account'|trans|capitalize }}</a></li>
+                    {% endblock %}
+                  {% endif %}
                   {% if is_granted('ROLE_PREVIOUS_ADMIN') %}
                     <li><a href="{{ path('index', {'_switch_user': '_exit'}) }}">{{ 'user.actions.switchBack'|trans|capitalize }}</a></li>
                   {% endif %}


### PR DESCRIPTION
The base template will throw an error that the msgphp is not set when we dont use the userbundle from the FrameworkBundle. For simple applications we should be able to get the data from the app user and provide just the login button