### PR TITLE
Include FontAwesome and Google Fonts (Lato) in the empty template

### DIFF
--- a/Resources/views/empty.html.twig
+++ b/Resources/views/empty.html.twig
@@ -25,6 +25,15 @@
     {{ encore_entry_link_tags('app') }}
   {% endblock %}
 
+  {# Fontawesome #}
+  {% block css_icons %}
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.2/css/solid.css" integrity="sha384-ioUrHig76ITq4aEJ67dHzTvqjsAP/7IzgwE7lgJcg2r7BRNGYSK0LwSmROzYtgzs" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.2/css/fontawesome.css" integrity="sha384-sri+NftO+0hcisDKgr287Y/1LVnInHJ1l+XC7+FOabmTTIK0HnE2ID+xxvJ21c5J" crossorigin="anonymous">
+  {% endblock %}
+
+  {# Google Fonts #}
+  <link href="https://fonts.googleapis.com/css?family=Lato:300,300i,400,400i,700,700i,900,900i&amp;display=swap" rel="stylesheet">
+
   {% block head_javascripts %}
     <script type="text/javascript">
       var jsData = {{ jsData|raw }};


### PR DESCRIPTION
These are in base.html.twig but not in empty.html.twig, resulting in no icons if you extend from that template.