### PR TITLE
Set default input format bootstrap datepicker

### DIFF
--- a/Form/Extension/DateTypeExtension.php
+++ b/Form/Extension/DateTypeExtension.php
@@ -32,6 +32,9 @@ final class DateTypeExtension extends AbstractTypeExtension
                 'maximum_date' => null,
                 'minimum_date' => null,
                 'html5' => false,
+                'attr' => [
+                    'data-format' => 'DD/MM/yyyy',
+                ],
             ]
         );
 


### PR DESCRIPTION
Sets the default input format for the bootstrap datepicker to match the default format. data-format string 'DD/MM/yyyy' currently matches 'dd/MM/yyyy' in bootstrap 4.6.0