### PR TITLE
Remove hidden attribute from collecion type add button

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -68,7 +68,7 @@
 
     {% if allow_add %}
       <div class="d-flex justify-content-end">
-        <button type="button" class="btn btn-outline-success btn-sm" data-role="collection-add-button" hidden>
+        <button type="button" class="btn btn-outline-success btn-sm" data-role="collection-add-button">
           <i class="fas fa-plus"></i> {{ 'forms.buttons.addItem'|trans|ucfirst }}
         </button>
       </div>


### PR DESCRIPTION
Our CollectionType form field used to have two add buttons, one on top and one near the bottom. We used to have a piece of JS in the FrameworkStylePackage that toggled one of these buttons depending on if there were already items present in the collection. In a recent [change](https://github.com/sumocoders/FrameworkCoreBundle/pull/48/files), we dropped the two button approach and only kept the 1 mandatory button at the bottom.

In https://github.com/sumocoders/FrameworkStylePackage/commit/611883d909d3d509a6c412c8a2b18791c9a5ab92#diff-3d4aa32b90131658ebe9969ce03de05196ef32a56bf8f0d6b3544c91e41a29a0, Katrien changed the JS code that toggled this hidden attribute, since it was no longer necessary. As a result, if you init a default CollectionType form right now, the button will be hidden, since the attribute is still hardcoded in its markup.