### PR TITLE
Check if the breadcrumbs variable is defined before trying to count them

### DIFF
--- a/Resources/views/BreadCrumb/breadCrumb.html.twig
+++ b/Resources/views/BreadCrumb/breadCrumb.html.twig
@@ -1,5 +1,5 @@
 {% block breadcrumb %}
-  {% if breadcrumbs.count %}
+  {% if breadcrumbs is defined and breadcrumbs.count %}
     <ol class="breadcrumb" itemscope itemtype="https://schema.org/breadcrumb">
       <li class="breadcrumb-item breadcrumb-item-back">
         <a href="/" data-button-previous="back" class="breadcrumb-link-back"><i class="fas fa-chevron-left fa-sm mr-2"></i><span class="sr-only d-md-none">{{ 'previous'|trans|ucfirst }}</span><span class="d-none d-md-inline-block">{{ 'previous'|trans|ucfirst }}</span></a>


### PR DESCRIPTION
In a new project with no breadcrumbs, the current default template will throw an error
as soon as the app is launched.