### PR TITLE
Move the toasts wrapper div inside the notification template

### DIFF
--- a/Resources/views/base.html.twig
+++ b/Resources/views/base.html.twig
@@ -48,9 +48,7 @@
 
       <section id="main" role="main">
         <div class="header-subbar">
-          <div class="toasts-wrapper" id="toast-wrapper">
-            {{ include('@SumoCodersFrameworkCore/notifications.html.twig') }}
-          </div>
+          {{ include('@SumoCodersFrameworkCore/notifications.html.twig') }}
           <div class="header-title-bar d-none d-md-flex justify-content-md-between align-items-md-center flex-column flex-md-row flex-wrap">
             <nav aria-label="breadcrumb" class="my-2">
               {{ block('breadcrumb', '@SumoCodersFrameworkCore/BreadCrumb/breadCrumb.html.twig') }}

--- a/Resources/views/notifications.html.twig
+++ b/Resources/views/notifications.html.twig
@@ -1,3 +1,4 @@
+{% block notifications %}
 <div class="toasts-wrapper" id="toast-wrapper">
   {% for flash_message in app.session.flashbag.get('success') %}
     <toast type="success" message="{{ flash_message }}"></toast>
@@ -15,3 +16,4 @@
     <toast type="danger" message="{{ flash_message }}"></toast>
   {% endfor %}
 </div>
+{% endblock %}

--- a/Resources/views/notifications.html.twig
+++ b/Resources/views/notifications.html.twig
@@ -1,15 +1,17 @@
-{% for flash_message in app.session.flashbag.get('success') %}
-  <toast type="success" message="{{ flash_message }}"></toast>
-{% endfor %}
+<div class="toasts-wrapper" id="toast-wrapper">
+  {% for flash_message in app.session.flashbag.get('success') %}
+    <toast type="success" message="{{ flash_message }}"></toast>
+  {% endfor %}
 
-{% for flash_message in app.session.flashbag.get('report') %}
-  <toast type="info" message="{{ flash_message }}"></toast>
-{% endfor %}
+  {% for flash_message in app.session.flashbag.get('report') %}
+    <toast type="info" message="{{ flash_message }}"></toast>
+  {% endfor %}
 
-{% for flash_message in app.session.flashbag.get('warning') %}
-  <toast type="warning" message="{{ flash_message }}"></toast>
-{% endfor %}
+  {% for flash_message in app.session.flashbag.get('warning') %}
+    <toast type="warning" message="{{ flash_message }}"></toast>
+  {% endfor %}
 
-{% for flash_message in app.session.flashbag.get('error') %}
-  <toast type="danger" message="{{ flash_message }}"></toast>
-{% endfor %}
+  {% for flash_message in app.session.flashbag.get('error') %}
+    <toast type="danger" message="{{ flash_message }}"></toast>
+  {% endfor %}
+</div>


### PR DESCRIPTION
I noticed we only wrapped the notifications include with the new Vue toast div in base.html.twig,
but this include is also used on user.html.twig and empty.html.twig. So the new toasts didn't work
on any template extending those, for example login pages, or register pages. I could've added
the div with the correct ID in those templates as well, but instead I moved the wrapper div
into the include, so all templates that use it will have the correct markup.