### PR TITLE
Fix collection type

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -51,6 +51,11 @@ services:
     tags:
       - { name: form.type_extension, extended_type: Symfony\Component\Form\Extension\Core\Type\ButtonType }
 
+  framework.collection_type_extension:
+    class: SumoCoders\FrameworkCoreBundle\Form\Extension\CollectionTypeExtension
+    tags:
+      - { name: form.type_extension, extended_type: Symfony\Component\Form\Extension\Core\Type\CollectionType }
+
   twig.framework_extension:
     class: SumoCoders\FrameworkCoreBundle\Twig\FrameworkExtension
     arguments:

--- a/src/Form/Extension/CollectionTypeExtension.php
+++ b/src/Form/Extension/CollectionTypeExtension.php
@@ -3,6 +3,8 @@
 namespace SumoCoders\FrameworkCoreBundle\Form\Extension;
 
 use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 
@@ -23,5 +25,10 @@ final class CollectionTypeExtension extends AbstractTypeExtension
                 'allow_drag_and_drop' => true,
             ]
         );
+    }
+
+    public function buildView(FormView $view, FormInterface $form, array $options)
+    {
+        $view->vars['allow_drag_and_drop'] = $options['allow_drag_and_drop'];
     }
 }


### PR DESCRIPTION
If you use the CollectionType you get the error:
`Variable "allow_drag_and_drop" does not exist.`

Make https://github.com/sumocoders/FrameworkCoreBundle/commit/ac8b159d6519e2ff98f46d82c7475122f88b32fa work
- The CollectionTypeExtension is not registered, so was never loaded
- The variable "allow_drag_and_drop" was never send to template