### PR TITLE
Encrypted type

### DIFF
--- a/docs/development/encrypted.md
+++ b/docs/development/encrypted.md
@@ -1,0 +1,12 @@
+# Encrypted strings in the database
+
+The core bundle has a DBAL type which encrypts strings with the built-in PHP libsodium functions. To use it, simply apply the type to a string in your entity.
+
+Example:
+```php
+    /**
+     * @ORM\Column(type="encrypted")
+     */
+    private string $encryptedString;
+```
+

--- a/src/DBALType/EncryptedDBALType.php
+++ b/src/DBALType/EncryptedDBALType.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace SumoCoders\FrameworkCoreBundle\DBALType;
+
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\ConversionException;
+
+class EncryptedDBALType extends Type
+{
+    const ENCRYPTED = 'encrypted';
+
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
+    {
+        return 'TEXT COMMENT \'(Encrypted)\'';
+    }
+
+    public function convertToPHPValue($value, AbstractPlatform $platform): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (!isset($_ENV['ENCRYPTION_KEY'])) {
+            throw new \RuntimeException('ENCRYPTION_KEY should be a valid 64 character key in your .env.local');
+        }
+
+        [$nonce, $encryptedValue] = explode('|', $value);
+
+        $decrypted =  sodium_crypto_secretbox_open(
+            sodium_hex2bin($encryptedValue),
+            sodium_hex2bin($nonce),
+            sodium_hex2bin($_ENV['ENCRYPTION_KEY'])
+        );
+
+        if ($decrypted === false) {
+            throw ConversionException::conversionFailed($value, $this->getName());
+        }
+
+        return $decrypted;
+    }
+
+    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (!isset($_ENV['ENCRYPTION_KEY'])) {
+            throw new \RuntimeException('ENCRYPTION_KEY should be a valid 64 character key in your .env.local');
+        }
+
+        $nonce = random_bytes(SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
+        $key = sodium_hex2bin($_ENV['ENCRYPTION_KEY']);
+
+        $encryptedValue = sodium_crypto_secretbox($value, $nonce, $key);
+
+        return sodium_bin2hex($nonce) . '|' . sodium_bin2hex($encryptedValue);
+    }
+
+    public function getName(): string
+    {
+        return self::ENCRYPTED;
+    }
+}


### PR DESCRIPTION
Encrypted DBAL type for encrypting strings in the database with libsodium.

https://github.com/sumocoders/application-skeleton/pull/48 provides the ENCRYPTION_KEY this functionality needs. Without that PR we have to add this key to our .env manually.