### PR TITLE
Refactor the format option for our translation dump command.

### DIFF
--- a/src/Command/TranslateCommand.php
+++ b/src/Command/TranslateCommand.php
@@ -28,7 +28,7 @@ class TranslateCommand extends Command
         $arguments = [
             'locale' => $locale,
             '--force' => true,
-            '--output-format' => 'yaml',
+            '--format' => 'yaml',
         ];
 
         $translationInput = new ArrayInput($arguments);


### PR DESCRIPTION
Deprecated: Since symfony/framework-bundle 5.3: The "--output-format" option is deprecated, use "--format=xlf12" instead.