### PR TITLE
Make the Route parameters an optional parameter

### DIFF
--- a/src/ValueObject/Route.php
+++ b/src/ValueObject/Route.php
@@ -7,7 +7,7 @@ class Route
     private string $name;
     private ?array $parameters;
 
-    public function __construct(string $name, ?array $parameters)
+    public function __construct(string $name, ?array $parameters = null)
     {
         $this->name = $name;
         $this->parameters = $parameters;
@@ -25,6 +25,10 @@ class Route
 
     public function addParameters(array $parameters): void
     {
+        if ($this->parameters === null) {
+            $this->parameters = $parameters;
+        }
+
         $this->parameters = array_merge($this->parameters, $parameters);
     }
 }


### PR DESCRIPTION
In some cases we need to generate a Route object without initial parameters
and add them later.