### PR TITLE
DateTime is passed

### DIFF
--- a/src/Form/Extension/DateTimeTypeExtension.php
+++ b/src/Form/Extension/DateTimeTypeExtension.php
@@ -32,10 +32,8 @@ final class DateTimeTypeExtension extends AbstractTypeExtension
 
     public function buildView(FormView $view, FormInterface $form, array $options): void
     {
-        $view->vars['maximum_date'] = $options['maximum_date'] ?
-            DateTime::createFromFormat($options['format'], $options['maximum_date']) : null;
-        $view->vars['minimum_date'] = $options['minimum_date'] ?
-            DateTime::createFromFormat($options['format'], $options['minimum_date']) : null;
+        $view->vars['maximum_date'] = $options['maximum_date'] ?? null;
+        $view->vars['minimum_date'] = $options['minimum_date'] ?? null;
         $view->vars['format'] = $options['format'];
         $view->vars['divider'] = (strpos($options['format'], '-') !== false) ? '-' : '/';
         $view->vars['helper_text'] = $options['helper_text'] ?? null;

--- a/src/Form/Extension/DateTypeExtension.php
+++ b/src/Form/Extension/DateTypeExtension.php
@@ -41,10 +41,8 @@ final class DateTypeExtension extends AbstractTypeExtension
 
     public function buildView(FormView $view, FormInterface $form, array $options): void
     {
-        $view->vars['maximum_date'] = $options['maximum_date'] ?
-            DateTime::createFromFormat($options['format'], $options['maximum_date']) : null;
-        $view->vars['minimum_date'] = $options['minimum_date'] ?
-            DateTime::createFromFormat($options['format'], $options['minimum_date']) : null;
+        $view->vars['maximum_date'] = $options['maximum_date'] ?? null;
+        $view->vars['minimum_date'] = $options['minimum_date'] ?? null;
         $view->vars['format'] = $options['format'];
         $view->vars['divider'] = (strpos($options['format'], '-') !== false) ? '-' : '/';
         $view->vars['datepicker'] = $options['datepicker'] ?? false;


### PR DESCRIPTION
The format from the options, is the one Symfony needs. This is not compatible with DateTime::createfromformat.
In our old docs there is also an example where we pass a DateTime object as min and max date