### PR TITLE
Auto-filling DTOs

### DIFF
--- a/src/DataTransferObject/BaseDataTransferObject.php
+++ b/src/DataTransferObject/BaseDataTransferObject.php
@@ -1,36 +1,56 @@
 <?php
 
-namespace SumoCoders\FrameworkCoreBundle\DataTransferObject;
+namespace App\DataTransferObject;
 
-use SumoCoders\FrameworkCoreBundle\Exception\DataTransferExceptionException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
 
 class BaseDataTransferObject
 {
-    public static function from(object $entity): static
+    protected object $source;
+
+    final public function __construct(?object $source = null)
     {
+        if ($source === null) {
+            return;
+        }
+
+        $this->source = $source;
+
         $propertyAccessor = PropertyAccess::createPropertyAccessor();
         $propertyInfo = new PropertyInfoExtractor(
-            [new ReflectionExtractor()]
+            [new ReflectionExtractor()],
+            [new ReflectionExtractor()],
+            [],
+            [new ReflectionExtractor()],
         );
 
         // Read all public properties of the child DTO that extends this class
         $properties = $propertyInfo->getProperties(static::class);
 
-        if (empty($properties)) {
-            throw new DataTransferExceptionException(sprintf('Found no public properties in $%1s.', static::class));
-        }
-
-        // Create a new instance of our child DTO
-        $dataTransferObject = new static();
-
-        // For each public property, try to look for a getter in the entity
         foreach ($properties as $property) {
-            $dataTransferObject->{$property} = $propertyAccessor->getValue($entity, $property);
-        }
+            // Only continue if the property is writable (a.k.a. public)
+            if ($propertyInfo->isWritable(static::class, $property)) {
+                // Get the value from the passed source object
+                $sourceValue = $propertyAccessor->getValue($source, $property);
 
-        return $dataTransferObject;
+                // Get the property type & class name
+                $type = $propertyInfo->getTypes(static::class, $property)[0];
+                $className = $type->getClassName();
+
+                // If the property is a class that extends this class, handle it recursively
+                if ($className !== null && is_subclass_of($className, self::class)) {
+                    $this->{$property} = new $className($sourceValue);
+                } else {
+                    $this->{$property} = $sourceValue;
+                }
+            }
+        }
+    }
+
+    public function getSource(): object
+    {
+        return $this->source;
     }
 }

--- a/src/DataTransferObject/BaseDataTransferObject.php
+++ b/src/DataTransferObject/BaseDataTransferObject.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace SumoCoders\FrameworkCoreBundle\DataTransferObject;
+
+use SumoCoders\FrameworkCoreBundle\Exception\DataTransferExceptionException;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
+
+class BaseDataTransferObject
+{
+    public static function from(object $entity): static
+    {
+        $propertyAccessor = PropertyAccess::createPropertyAccessor();
+        $propertyInfo = new PropertyInfoExtractor(
+            [new ReflectionExtractor()]
+        );
+
+        // Read all public properties of the child DTO that extends this class
+        $properties = $propertyInfo->getProperties(static::class);
+
+        if (empty($properties)) {
+            throw new DataTransferExceptionException(sprintf('Found no public properties in $%1s.', static::class));
+        }
+
+        // Create a new instance of our child DTO
+        $dataTransferObject = new static();
+
+        // For each public property, try to look for a getter in the entity
+        foreach ($properties as $property) {
+            $dataTransferObject->{$property} = $propertyAccessor->getValue($entity, $property);
+        }
+
+        return $dataTransferObject;
+    }
+}

--- a/src/Exception/DataTransferExceptionException.php
+++ b/src/Exception/DataTransferExceptionException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace SumoCoders\FrameworkCoreBundle\Exception;
+
+final class DataTransferExceptionException extends \RuntimeException
+{
+}


### PR DESCRIPTION
DTOs are useful, but in large projects you end up having to write a lot of boilerplate code to simply pass data from Entity -> DTO and back from DTO -> entity. This PR introduces a new `BaseDataTransferObject`, which has a "magic" constructor that populates all public properties of a DTO with the matching value it can find if an object is passed to the constructor.

Address DTO
```php
<?php

namespace App\DataTransferObject\Common;

use App\DataTransferObject\BaseDataTransferObject;
use App\Enum\Province;
use Symfony\Component\Validator\Constraints as Assert;

class AddressDataTransferObject extends BaseDataTransferObject
{
    #[Assert\NotBlank]
    public ?string $street = null;

    #[Assert\NotBlank]
    public ?string $number = null;

    #[Assert\NotBlank]
    public ?string $zipCode = null;

    #[Assert\NotBlank]
    public ?string $city = null;

    public Province $province = Province::EastFlanders;

    // NO constructor, uses the parent constructor from BaseDTO
}
```

```php
<?php

// If nothing is passed to the constructor, nothing gets populated
$createAddress = new createAddress();

// If an entity is passed, the matching properties will be populated
$addressDTO = new AddressDataTransferObject($address);

For example `public string $street` will be be filled from `$address->getStreet()`

// If a message extends from the addressDTO, it will also work
$updateAddress = new UpdateAddress($address);

// If one of the properties in the DTO is also a DTO, it will work recursively
```

This will save exactly 3.5 minutes for every new DTO that we use :smile: 