### PR TITLE
Allow HTML for real

### DIFF
--- a/templates/Form/fields.html.twig
+++ b/templates/Form/fields.html.twig
@@ -411,3 +411,42 @@
     {% endif %}
   </select>
 {% endblock %}
+
+{% block form_help -%}
+  {% set row_class = row_attr.class|default('') %}
+  {% set help_class = ' form-text' %}
+  {% if 'input-group' in row_class %}
+    {#- Hack to properly display help with input group -#}
+    {% set help_class = ' input-group-text' %}
+  {% endif %}
+  {%- if help is not empty -%}
+    {%- set help_attr = help_attr|merge({class: (help_attr.class|default('') ~ help_class ~ ' mb-0')|trim}) -%}
+  {%- endif -%}
+
+  {%- if help is not empty -%}
+    {%- set help_attr = help_attr|merge({class: (help_attr.class|default('') ~ ' help-text')|trim}) -%}
+    {%- if help_html is same as(false) -%}
+    <p id="{{ id }}_help"{% with { attr: help_attr } %}{{ block('attributes') }}{% endwith %}>
+    {%- else -%}
+      <div id="{{ id }}_help"{% with { attr: help_attr } %}{{ block('attributes') }}{% endwith %}>
+    {%- endif -%}
+    {%- if translation_domain is same as(false) -%}
+      {%- if help_html is same as(false) -%}
+        {{- help -}}
+      {%- else -%}
+        {{- help|raw -}}
+      {%- endif -%}
+    {%- else -%}
+      {%- if help_html is same as(false) -%}
+        {{- help|trans(help_translation_parameters, translation_domain) -}}
+      {%- else -%}
+        {{- help|trans(help_translation_parameters, translation_domain)|raw -}}
+      {%- endif -%}
+    {%- endif -%}
+    {%- if help_html is same as(false) -%}
+      </p>
+    {%- else -%}
+      </div>
+    {%- endif -%}
+  {%- endif -%}
+{%- endblock form_help %}


### PR DESCRIPTION
Allow HTML to be used in help text.

If you provide HTML as a `help` text it was wrapped in a `<p>`-tag. This rendered invalid HTML as can be seen below:
![invalid](https://user-images.githubusercontent.com/250042/158210613-fc638295-4f18-4f51-b1d1-b1ca9f797c92.png)
It also looked faulty, as the classes were not preserved with new `<p>`-tags.
![before](https://user-images.githubusercontent.com/250042/158210610-a2b74b46-a8e2-4455-8705-6665ab0a2653.png)

With this PR applied, it will look like:
![after](https://user-images.githubusercontent.com/250042/158210607-2fb6fd4d-f526-48a3-b201-7ca38ada34c9.png)
