### PR TITLE
Introduce a helper method to toggle sub-menu dropdowns on page load.

### DIFF
--- a/src/EventListener/DefaultMenuListener.php
+++ b/src/EventListener/DefaultMenuListener.php
@@ -52,4 +52,24 @@ class DefaultMenuListener
             );
         }
     }
+
+    public function toggleDropdowns(itemInterface $menu)
+    {
+        $request = $this->requestStack->getCurrentRequest();
+
+        // Loop over all the defined menu items
+        foreach ($menu->getChildren() as $child) {
+            // If a menu has children -> it has a sub-menu
+            if ($child->hasChildren()) {
+                foreach ($child->getExtra('routes') as $routes) {
+                    // If the current route is inside the sub-menu
+                    if ($routes['route'] === $request->get('_route')) {
+                        // Toggle the dropdown to active on page load
+                        $child->setAttribute('class', 'show');
+                        $child->setChildrenAttribute('class', 'show');
+                    }
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
We can't do this in the core bundle for every menu, because the $menu passed to this method is defined inside the event listener in the project. If anyone has an idea to make this work out-fo-the-box, without forcing the dev to call this method in each project, I'd be happy to hear it :)

Right now you'd have to do this in your project menu listener:

```php
class MenuListener extends DefaultMenuListener
{
    public function onConfigureMenu(ConfigureMenuEvent $event): void
    {
        $factory = $event->getFactory();
        $menu = $event->getMenu();

        // add all your menu items
        // $menu->addItem bla bla

        $this->toggleDropdowns($menu);
    }
}
```