### PR TITLE
Bump the minimum Symfony version to 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,15 +23,15 @@
   "require": {
     "php": "^8.0",
     "gedmo/doctrine-extensions": "^3",
-    "friendsofsymfony/jsrouting-bundle": "^2",
+    "friendsofsymfony/jsrouting-bundle": "^3",
     "knplabs/knp-menu-bundle": "^3.0",
     "sensio/framework-extra-bundle": "^6.1",
-    "symfony/form": "^5.3 || 6.0",
-    "symfony/asset": "^5.3 || 6.0",
-    "symfony/console": "^5.3 || 6.0",
-    "symfony/security-bundle": "^5.3 || 6.0",
-    "symfony/translation": "^5.3 || 6.0",
-    "symfony/twig-bundle": "^5.3 || 6.0",
+    "symfony/form": "^6.0",
+    "symfony/asset": "^6.0",
+    "symfony/console": "^6.0",
+    "symfony/security-bundle": "^6.0",
+    "symfony/translation": "^6.0",
+    "symfony/twig-bundle": "^6.0",
     "twig/inky-extra": "^3.3",
     "twig/cssinliner-extra": "^3.3",
     "twig/extra-bundle": "^3.3"
@@ -39,7 +39,7 @@
   "require-dev": {
     "roave/security-advisories": "dev-master",
     "symfony/phpunit-bridge": "^6.0",
-    "friendsoftwig/twigcs": "^5.0",
+    "friendsoftwig/twigcs": "^6.0",
     "symfony/maker-bundle": "^1.0"
   },
   "autoload": {


### PR DESCRIPTION
composer install getest, geen dependency errors. buiten de symfony packages 2 grote bumps:
* [friendsofsymfony/twigcs](https://github.com/friendsoftwig/twigcs/releases/tag/v6.0.0)
* [friendsofsymfony/jsroutingbundle](https://github.com/FriendsOfSymfony/FOSJsRoutingBundle/releases/tag/3.0.0)

Ik voorzie voor beide geen changes die ons beinvloeden, maar ik volg het op tijdens het testen van de skeleton create-project. 

Daarvoor is eerst een release nodig die 6/6.1 allowed.