### PR TITLE
Defer the loading of the JS translations dump

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -76,9 +76,8 @@
 {{ include('@SumoCodersFrameworkCore/dialogs.html.twig') }}
 
 {% block javascripts %}
-  <script src="{{ url('bazinga_jstranslation_js') }}"></script>
-
   {{ encore_entry_script_tags('app') }}
+  <script src="{{ url('bazinga_jstranslation_js') }}" defer></script>
 {% endblock %}
 </body>
 </html>


### PR DESCRIPTION
We need our app.js to initialize and provide the global Translator for the translations to work without an error.

See: https://github.com/sumocoders/FrameworkStylePackage/pull/108