### PR TITLE
Allow "img-src: data:" in CSP for bootstrap icons

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -24,6 +24,10 @@ class Configuration implements ConfigurationInterface
                         'font-src' => [
                             "'self'",
                         ],
+                        'img-src' => [
+                            "'self'",
+                            "data:", // Bootstrap icons
+                        ],
                         'child-src' => [
                             "'none'", // Block all iframes
                         ],


### PR DESCRIPTION
Checkboxes/radiobuttons use a data: svg icon to indicate selected state.