### PR TITLE
Add additional var parameter to use a custom add button label

### DIFF
--- a/src/Form/Extension/CollectionTypeExtension.php
+++ b/src/Form/Extension/CollectionTypeExtension.php
@@ -23,6 +23,7 @@ final class CollectionTypeExtension extends AbstractTypeExtension
         $resolver->setDefaults(
             [
                 'allow_drag_and_drop' => true,
+                'add_btn_label' => 'forms.buttons.addItem',
             ]
         );
     }
@@ -30,5 +31,6 @@ final class CollectionTypeExtension extends AbstractTypeExtension
     public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $view->vars['allow_drag_and_drop'] = $options['allow_drag_and_drop'];
+        $view->vars['add_btn_label'] = $options['add_btn_label'];
     }
 }

--- a/src/Form/Extension/CollectionTypeExtension.php
+++ b/src/Form/Extension/CollectionTypeExtension.php
@@ -23,7 +23,7 @@ final class CollectionTypeExtension extends AbstractTypeExtension
         $resolver->setDefaults(
             [
                 'allow_drag_and_drop' => true,
-                'add_btn_label' => 'forms.buttons.addItem',
+                'add_button_label' => 'forms.buttons.addItem',
             ]
         );
     }
@@ -31,6 +31,6 @@ final class CollectionTypeExtension extends AbstractTypeExtension
     public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $view->vars['allow_drag_and_drop'] = $options['allow_drag_and_drop'];
-        $view->vars['add_btn_label'] = $options['add_btn_label'];
+        $view->vars['add_button_label'] = $options['add_button_label'];
     }
 }

--- a/templates/Form/fields.html.twig
+++ b/templates/Form/fields.html.twig
@@ -110,7 +110,7 @@
 
     {% if allow_add %}
       <button type="button" class="btn btn-success btn-sm" data-role="collection-add-button">
-        <i class="fas fa-plus me-2"></i> {{ form.vars.form_btn_label|trans|ucfirst }}
+        <i class="fas fa-plus me-2"></i> {{ form.vars.add_button_label|trans|ucfirst }}
       </button>
     {% endif %}
   {% endapply %}

--- a/templates/Form/fields.html.twig
+++ b/templates/Form/fields.html.twig
@@ -110,7 +110,7 @@
 
     {% if allow_add %}
       <button type="button" class="btn btn-success btn-sm" data-role="collection-add-button">
-        <i class="fas fa-plus me-2"></i> {{ form.vars.add_button_label|trans|ucfirst }}
+        <i class="fas fa-plus me-2"></i> {{ add_button_label|trans|ucfirst }}
       </button>
     {% endif %}
   {% endapply %}

--- a/templates/Form/fields.html.twig
+++ b/templates/Form/fields.html.twig
@@ -110,7 +110,7 @@
 
     {% if allow_add %}
       <button type="button" class="btn btn-success btn-sm" data-role="collection-add-button">
-        <i class="fas fa-plus me-2"></i> {{ 'forms.buttons.addItem'|trans|ucfirst }}
+        <i class="fas fa-plus me-2"></i> {{ form.vars.form_btn_label|trans|ucfirst }}
       </button>
     {% endif %}
   {% endapply %}


### PR DESCRIPTION
Makes it possible to use a custom label for the add button in a collection type

```php
    public function buildForm(FormBuilderInterface $builder, array $options): void
    {
        $builder
            ->add(
                'keys',
                CollectionType::class,
                [
                    'label' => false,
                    'entry_type' => AddKeyType::class,
                    'allow_add' => true,
                    'allow_delete' => true,
                    'add_btn_label' => 'forms.buttons.addKey',
                ]
            );
    }
```