### PR TITLE
Use fallback path when no referer is known

### DIFF
--- a/templates/Error/error403.html.twig
+++ b/templates/Error/error403.html.twig
@@ -3,9 +3,5 @@
 {% block body %}
     <h1>{{ 'error.messages.unauthorized'|trans }}</h1>
     <p>{{ 'error.messages.unauthorizedMessage'|trans }}</p>
-    {% if app.request.headers.get('referer') != "" %}
-        <a href="{{ app.request.headers.get('referer') }}" class="btn btn-outline-primary">{{ 'go back'|trans }}</a>
-    {% else %}
-        <a href="{{ fallbacks.get('redirect_path') }}" class="btn btn-outline-primary">{{ 'go back'|trans }}</a>
-    {% endif %}
+    <a href="{{ app.request.headers.get('referer')|default(fallbacks.get('redirect_path')) }}" class="btn btn-outline-primary">{{ 'go back'|trans }}</a>
 {% endblock %}

--- a/templates/Error/error403.html.twig
+++ b/templates/Error/error403.html.twig
@@ -3,5 +3,9 @@
 {% block body %}
     <h1>{{ 'error.messages.unauthorized'|trans }}</h1>
     <p>{{ 'error.messages.unauthorizedMessage'|trans }}</p>
-    <a href="{{ app.request.headers.get('referer') }}" class="btn btn-outline-primary">{{ 'go back'|trans }}</a>
+    {% if app.request.headers.get('referer') != "" %}
+        <a href="{{ app.request.headers.get('referer') }}" class="btn btn-outline-primary">{{ 'go back'|trans }}</a>
+    {% else %}
+        <a href="{{ fallbacks.get('redirect_path') }}" class="btn btn-outline-primary">{{ 'go back'|trans }}</a>
+    {% endif %}
 {% endblock %}

--- a/templates/Error/error403.html.twig
+++ b/templates/Error/error403.html.twig
@@ -3,5 +3,5 @@
 {% block body %}
     <h1>{{ 'error.messages.unauthorized'|trans }}</h1>
     <p>{{ 'error.messages.unauthorizedMessage'|trans }}</p>
-    <a href="{{ app.request.headers.get('referer')|default(fallbacks.get('redirect_path')) }}" class="btn btn-outline-primary">{{ 'go back'|trans }}</a>
+    <a href="{{ app.request.headers.get('referer')|default(fallbacks.get('redirect_path', '/')) }}" class="btn btn-outline-primary">{{ 'go back'|trans }}</a>
 {% endblock %}


### PR DESCRIPTION
Use the fallback redirect path when navigating directly to a 403 page