### PR TITLE
Provide a default value for the fallbacks parameter

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -33,6 +33,9 @@ use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $container): void {
+    $container->parameters()
+        ->set('fallbacks', []);
+
     $container->services()
         ->defaults()
         ->autowire()


### PR DESCRIPTION
Fixes an issue with the application-skeleton

Provides a fallback value for the fallbacks parameter before this is set during the initialisation of project 