### PR TITLE
Fix composer conflicts for framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "twig/extra-bundle": "^3.3",
     "symfony/ux-autocomplete": "^2.8",
     "doctrine/doctrine-bundle": "^2.11",
-    "doctrine/orm": "^3.0"
+    "doctrine/orm": "^2.0"
   },
   "require-dev": {
     "roave/security-advisories": "dev-master",

--- a/config/services.php
+++ b/config/services.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 use SumoCoders\FrameworkCoreBundle\Command\SecretsGetCommand;
 use SumoCoders\FrameworkCoreBundle\Command\TranslateCommand;
+use SumoCoders\FrameworkCoreBundle\DoctrineListener\DoctrineAuditListener;
 use SumoCoders\FrameworkCoreBundle\EventListener\TitleListener;
+use SumoCoders\FrameworkCoreBundle\Logger\AuditLogger;
 use SumoCoders\FrameworkCoreBundle\Service\PageTitle;
 use SumoCoders\FrameworkCoreBundle\Twig\ContentExtension;
 use Symfony\Component\Form\Extension\Core\Type\TimeType;
@@ -163,5 +165,8 @@ return static function (ContainerConfigurator $container): void {
         ->args([
             service('secrets.vault')
         ])
-        ->tag('console.command');
+        ->tag('console.command')
+
+        ->set(DoctrineAuditListener::class)
+        ->set(AuditLogger::class);
 };


### PR DESCRIPTION
Use doctrine ^2.0 since doctrine 3.0 isn't used by symfony yet
Add services to load doctrine listener and audit logger