### PR TITLE
Fix form label raw filter

### DIFF
--- a/templates/Form/fields.html.twig
+++ b/templates/Form/fields.html.twig
@@ -29,7 +29,7 @@
       {%- if label_html is same as(false) -%}
         {{- label|trans(label_translation_parameters, translation_domain)|ucfirst -}}&#32;{{- block('label_asterisk') }}
       {%- else -%}
-        {{- label|trans(label_translation_parameters, translation_domain)|raw|ucfirst -}}&#32;{{- block('label_asterisk') }}
+        {{- label|trans(label_translation_parameters, translation_domain)|ucfirst|raw -}}&#32;{{- block('label_asterisk') }}
       {%- endif -%}
     {%- endif -%}
     </{{ element|default('label') }}>


### PR DESCRIPTION
Raw only works if applied last.
Makes `'label_html' => true` in form options work again.