### PR TITLE
Don't fail on entities that are not found

### DIFF
--- a/src/EventListener/BreadcrumbListener.php
+++ b/src/EventListener/BreadcrumbListener.php
@@ -3,6 +3,7 @@
 namespace SumoCoders\FrameworkCoreBundle\EventListener;
 
 use Doctrine\ORM\EntityManagerInterface;
+use SumoCoders\FrameworkCoreBundle\Exception\Breadcrumb\EntityNotFoundException;
 use SumoCoders\FrameworkCoreBundle\ValueObject\Route;
 use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
@@ -95,12 +96,16 @@ class BreadcrumbListener
                 $this->addBreadcrumbsForParent($attributeInstance->getParent());
             }
 
-            $this->breadcrumbTrail->add(
-                $this->generateBreadcrumb(
-                    $attributeInstance,
-                    $method
-                )
-            );
+            try {
+                $this->breadcrumbTrail->add(
+                    $this->generateBreadcrumb(
+                        $attributeInstance,
+                        $method
+                    )
+                );
+            } catch (EntityNotFoundException $e) {
+
+            }
         }
     }
 
@@ -159,7 +164,7 @@ class BreadcrumbListener
             }
 
             if (!is_object($attribute)) {
-                throw new RuntimeException(
+                throw new EntityNotFoundException(
                     'Could not resolve entity ' . $name . ' with ID ' . $attributeId
                 );
             }

--- a/src/Exception/Breadcrumb/EntityNotFoundException.php
+++ b/src/Exception/Breadcrumb/EntityNotFoundException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace SumoCoders\FrameworkCoreBundle\Exception\Breadcrumb;
+
+final class EntityNotFoundException extends \RuntimeException
+{
+}


### PR DESCRIPTION
With this fix no exception will be thrown when the entity can't be resolved.
If you are using Action arguments (where the Entity will be resolved automatically) this will result in a 404 Not found. Which is a expected behavior in my opinion. 