### PR TITLE
Fix multiple buttons in header navigation

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -52,7 +52,7 @@
             </nav>
             <div class="ms-md-auto">
               {% if block('header_navigation') is defined and block('header_navigation') is not empty %}
-                <div class="action-buttons">
+                <div class="d-flex gap-2 align-items-center">
                   {{ block('header_navigation') }}
                 </div>
               {% endif %}


### PR DESCRIPTION
When I added the extra button for forgot password in user bundle, the button didn't align next to the block button, this fixes it