### PR TITLE
Fix nested form collection types

### DIFF
--- a/assets-public/controllers/form_collection_controller.js
+++ b/assets-public/controllers/form_collection_controller.js
@@ -54,11 +54,13 @@ export default class extends Controller {
     document.dispatchEvent(new Event('add.collection.item'))
 
     let prototype = this.element.dataset.prototype
+    let prototypeName = this.element.dataset.prototypeName
     // get the new index
     const index = parseInt(this.element.dataset.index)
-    // Replace '__name__' in the prototype's HTML to
+    // Replace prototype name (default '__name__') in the prototype's HTML to
     // instead be a number based on how many items we have
-    prototype = prototype.replace(/__name__/g, index)
+    const regex = new RegExp(prototypeName, 'g')
+    prototype = prototype.replace(regex, index)
     // increase the index with one for the next item
     this.element.dataset.index = index + 1
 


### PR DESCRIPTION
For nested form collection types to work, we need to set different prototype name. In this example:  field___name___sub___name__, both collection type have the same prototype name and will both be replaced when adding an item in the first collection type.

To make field___name___sub___name2__ work, we need to read the prototype name from the dataset when replacing it in JavaScript.

## Summary by Sourcery

Use the prototypeName data attribute when replacing placeholders in the form collection controller to correctly handle nested collection types.

Bug Fixes:
- Prevent incorrect placeholder replacement in nested form collections by using the dynamic dataset prototypeName instead of the hardcoded '__name__'

Enhancements:
- Add support for custom prototypeName in the form collection controller to enable nested collections