### PR TITLE
Allow row classes in the time widget

### DIFF
--- a/templates/Form/fields.html.twig
+++ b/templates/Form/fields.html.twig
@@ -257,8 +257,8 @@
   {%- if help is not empty -%}
     {%- set widget_attr = {attr: {'aria-describedby': id ~ "_help"}} -%}
   {%- endif -%}
-  {% set row_classes = ['form-group']|merge(form.vars.row_attr.class|split(' ')) -%}
-  <{{ element|default('div') }} class="{{ classes|join(' ') }}">
+  {% set row_classes = ['form-group']|merge(form.vars.row_attr.class|default('')|split(' ')) -%}
+  <{{ element|default('div') }} class="{{ row_classes|join(' ') }}">
   {{- form_label(form) -}}
   {{- form_widget(form, widget_attr) -}}
   </{{ element|default('div') }}>

--- a/templates/Form/fields.html.twig
+++ b/templates/Form/fields.html.twig
@@ -257,7 +257,8 @@
   {%- if help is not empty -%}
     {%- set widget_attr = {attr: {'aria-describedby': id ~ "_help"}} -%}
   {%- endif -%}
-  <{{ element|default('div') }} class="form-group">
+  {% set row_classes = ['form-group']|merge(form.vars.row_attr.class|split(' ')) -%}
+  <{{ element|default('div') }} class="{{ classes|join(' ') }}">
   {{- form_label(form) -}}
   {{- form_widget(form, widget_attr) -}}
   </{{ element|default('div') }}>


### PR DESCRIPTION
Allow to set classes on the row
Eg: when used in a collection

## Summary by Sourcery

New Features:
- Support specifying custom row CSS classes via form row attributes for the time widget.