### PR TITLE
Fix multiple renders of header action blocks

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -87,9 +87,9 @@
         {% endif %}
         {% if has_header_actions %}
           <div class="buttons-fixed{% if not sidebarIsOpen() %} sidebar-collapsed{% endif %}" data-sidebar-collapsable-target="toggleable">
-            <div class="order-1 order-lg-0">{% block header_actions_left %}{% endblock %}</div>
-            <div class="order-0 order-lg-1 d-flex flex-wrap justify-content-center gap-1 buttons-fixed-center">{% block header_actions_center %}{% endblock %}</div>
-            <div class="order-2">{% block header_actions_right %}{% endblock %}</div>
+            <div class="order-1 order-lg-0">{{ has_header_actions_left|raw }}</div>
+            <div class="order-0 order-lg-1 d-flex flex-wrap justify-content-center gap-1 buttons-fixed-center">{{ has_header_actions_center|raw }}</div>
+            <div class="order-2">{{ has_header_actions_right|raw }}</div>
           </div>
         {% endif %}
       </div>


### PR DESCRIPTION
Render the block from variables instead of rendering it multiple times. Form elements don't like being renderen multiple times.

## Summary by Sourcery

Bug Fixes:
- Avoid multiple renders of header action blocks that could break stateful form elements in the header.