### PR TITLE
Fix: commit reference.php after automatic composer update

### DIFF
--- a/src/Command/Maintenance/CreatePrForOutdatedDependenciesCommand.php
+++ b/src/Command/Maintenance/CreatePrForOutdatedDependenciesCommand.php
@@ -224,7 +224,7 @@ class CreatePrForOutdatedDependenciesCommand
                 true
             );
 
-            $this->runCommand(['git', 'add', 'composer.json', 'composer.lock', 'symfony.lock']);
+            $this->runCommand(['git', 'add', 'composer.json', 'composer.lock', 'symfony.lock', 'config/reference.php']);
             $versionMessages[] = sprintf(
                 '  * %1$s (%2$s → %3$s)',
                 $package['name'],


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Stage config/reference.php alongside composer.json, composer.lock, and symfony.lock when creating dependency update commits so reference changes are not omitted.