### PR TITLE
416 Symfony ux 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "twig/inky-extra": "^3.16",
     "twig/cssinliner-extra": "^3.16",
     "twig/extra-bundle": "^3.16",
-    "symfony/ux-autocomplete": "^2.22",
+    "symfony/ux-autocomplete": "^3.0",
     "doctrine/doctrine-bundle": "^3.2",
     "doctrine/orm": "^3.3",
     "symfony/doctrine-messenger": "^8.0",

--- a/docs/development/autocomplete.md
+++ b/docs/development/autocomplete.md
@@ -43,7 +43,7 @@ If you want to use ajax to fetch the autocomplete options, you need to create a 
 ```php
 use Symfony\Component\Security\Core\Security;
 use Symfony\UX\Autocomplete\Form\AsEntityAutocompleteField;
-use Symfony\UX\Autocomplete\Form\ParentEntityAutocompleteType;
+use Symfony\UX\Autocomplete\Form\BaseEntityAutocompleteType;
 
 #[AsEntityAutocompleteField]
 class FoodAutocompleteField extends AbstractType
@@ -68,7 +68,7 @@ class FoodAutocompleteField extends AbstractType
 
     public function getParent(): string
     {
-        return ParentEntityAutocompleteType::class;
+        return BaseEntityAutocompleteType::class;
     }
 }
 ```


### PR DESCRIPTION
## Summary by Sourcery

Update Symfony UX autocomplete integration to the 3.0 version and align documentation accordingly.

Build:
- Bump symfony/ux-autocomplete dependency from ^2.22 to ^3.0.

Documentation:
- Update autocomplete development documentation to reference BaseEntityAutocompleteType instead of ParentEntityAutocompleteType.