### PR TITLE
fix: theme status not updated in toggler on page load

### DIFF
--- a/assets-public/controllers/theme_controller.js
+++ b/assets-public/controllers/theme_controller.js
@@ -28,8 +28,6 @@ export default class extends Controller {
       }
     }
 
-    setTheme(getPreferredTheme())
-
     const showActiveTheme = (theme, focus = false) => {
       const themeSwitcher = document.querySelector('#bd-theme')
 
@@ -64,6 +62,9 @@ export default class extends Controller {
         themeSwitcher.focus()
       }
     }
+
+    setTheme(getPreferredTheme())
+    showActiveTheme(getPreferredTheme())
 
     window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
       const storedTheme = getStoredTheme()


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix theme switcher not displaying the correct active theme state when the page first loads.