### PR TITLE
fix ImageType NotBlank constraint

### DIFF
--- a/src/Form/Type/FileType.php
+++ b/src/Form/Type/FileType.php
@@ -49,7 +49,7 @@ class FileType extends AbstractType
                     if ($required) {
                         $fileFieldOptions['constraints'] = [
                             new NotBlank(
-                                ['message' => $options['required_file_error']]
+                                message: $options['required_file_error']
                             ),
                         ];
                     }

--- a/src/Form/Type/ImageType.php
+++ b/src/Form/Type/ImageType.php
@@ -49,7 +49,7 @@ class ImageType extends AbstractType
                     if ($required) {
                         $fileFieldOptions['constraints'] = [
                             new NotBlank(
-                                ['message' => $options['required_image_error']]
+                                message: $options['required_image_error']
                             ),
                         ];
                     }


### PR DESCRIPTION
## Bug fix

Passing an array of options to a Constraint is deprecated

## Summary by Sourcery

Bug Fixes:
- Replace deprecated array-based options in the NotBlank constraint with a named argument to ensure compatibility with newer Symfony validation APIs.