### PR TITLE
Fix symfony form type deprecation

### DIFF
--- a/src/DBALType/AbstractFileType.php
+++ b/src/DBALType/AbstractFileType.php
@@ -8,31 +8,31 @@ use SumoCoders\FrameworkCoreBundle\ValueObject\AbstractFile;
 
 abstract class AbstractFileType extends Type
 {
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
         return 'VARCHAR(255)';
     }
 
     /**
-     * @param string $fileName
+     * @param string $value
      * @param AbstractPlatform $platform
      *
      * @return AbstractFile|null
      */
-    public function convertToPHPValue($fileName, AbstractPlatform $platform): ?AbstractFile
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): mixed
     {
-        return $this->createFromString($fileName);
+        return $this->createFromString($value);
     }
 
     /**
-     * @param AbstractFile $file
+     * @param AbstractFile $value
      * @param AbstractPlatform $platform
      *
      * @return string|null
      */
-    public function convertToDatabaseValue($file, AbstractPlatform $platform): ?string
+    public function convertToDatabaseValue(mixed $value, AbstractPlatform $platform): mixed
     {
-        return $file !== null ? (string) $file : null;
+        return $value !== null ? (string) $value : null;
     }
 
     abstract protected function createFromString(string $fileName): ?AbstractFile;

--- a/src/DBALType/AbstractImageType.php
+++ b/src/DBALType/AbstractImageType.php
@@ -9,36 +9,36 @@ use SumoCoders\FrameworkCoreBundle\ValueObject\AbstractImage;
 abstract class AbstractImageType extends Type
 {
     /**
-     * @param array $fieldDeclaration
+     * @param array $column
      * @param AbstractPlatform $platform
      *
      * @return string
      */
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
         return 'VARCHAR(255)';
     }
 
     /**
-     * @param string $imageName
+     * @param string $value
      * @param AbstractPlatform $platform
      *
      * @return AbstractImage|null
      */
-    public function convertToPHPValue($imageName, AbstractPlatform $platform): ?AbstractImage
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): mixed
     {
-        return $this->createFromString($imageName);
+        return $this->createFromString($value);
     }
 
     /**
-     * @param AbstractImage $image
+     * @param AbstractImage $value
      * @param AbstractPlatform $platform
      *
      * @return string|null
      */
-    public function convertToDatabaseValue($image, AbstractPlatform $platform): ?string
+    public function convertToDatabaseValue(mixed $value, AbstractPlatform $platform): mixed
     {
-        return $image !== null ? (string) $image : null;
+        return $value !== null ? (string) $value : null;
     }
 
     abstract protected function createFromString(string $imageName): ?AbstractImage;

--- a/src/DBALType/EncryptedDBALType.php
+++ b/src/DBALType/EncryptedDBALType.php
@@ -15,7 +15,7 @@ class EncryptedDBALType extends Type
         return 'TEXT COMMENT \'(Encrypted)\'';
     }
 
-    public function convertToPHPValue($value, AbstractPlatform $platform): ?string
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): mixed
     {
         if ($value === null) {
             return null;
@@ -40,7 +40,7 @@ class EncryptedDBALType extends Type
         return $decrypted;
     }
 
-    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    public function convertToDatabaseValue(mixed $value, AbstractPlatform $platform): mixed
     {
         if ($value === null) {
             return null;


### PR DESCRIPTION
## Summary by Sourcery

Update custom DBAL types to align with newer Doctrine type signatures and type-hinting requirements.

Enhancements:
- Align image, file, and encrypted DBAL types with updated Doctrine type signatures using generic mixed value parameters and return types.
- Rename SQL declaration parameter from field declaration to column for consistency with Doctrine platform expectations.