### PR TITLE
Fix sass build

### DIFF
--- a/assets/scss/base/_fonts.scss
+++ b/assets/scss/base/_fonts.scss
@@ -1,4 +1,4 @@
-/* Example for importing fonts
+/* Example for importing fonts */
 // @mixin font-import($font-name, $font-file, $style: normal, $weight: 400) {
 //  @font-face {
 //    font-family: "#{$font-name}";


### PR DESCRIPTION
console sass:build fails without closing comment

## Summary by Sourcery

Bug Fixes:
- Fix unclosed comment in _fonts.scss that caused sass:build to fail.