### PR TITLE
Inline mail CSS via AssetMapper instead of static file path

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
     "symfony/intl": "^8.0",
     "nelmio/security-bundle": "^3.7",
     "symfony/validator": "^8.0",
-    "symfony/http-client": "^8.0"
+    "symfony/http-client": "^8.0",
+    "symfony/asset-mapper": "^8.0"
   },
   "require-dev": {
     "roave/security-advisories": "dev-master",

--- a/config/services.php
+++ b/config/services.php
@@ -25,6 +25,7 @@ use SumoCoders\FrameworkCoreBundle\Service\PageTitle;
 use SumoCoders\FrameworkCoreBundle\Service\Security\NonceGenerator;
 use SumoCoders\FrameworkCoreBundle\Twig\ContentExtension;
 use SumoCoders\FrameworkCoreBundle\Twig\FrameworkExtension;
+use SumoCoders\FrameworkCoreBundle\Twig\MailCssExtension;
 use SumoCoders\FrameworkCoreBundle\Twig\PaginatorExtension;
 use SumoCoders\FrameworkCoreBundle\Twig\PaginatorRuntime;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
@@ -111,6 +112,9 @@ return static function (ContainerConfigurator $container): void {
         ->tag('twig.attribute_extension')
 
         ->set('framework.content_extension', ContentExtension::class)
+        ->tag('twig.attribute_extension')
+
+        ->set('framework.mail_css_extension', MailCssExtension::class)
         ->tag('twig.attribute_extension')
 
         /*

--- a/config/services.php
+++ b/config/services.php
@@ -23,9 +23,9 @@ use SumoCoders\FrameworkCoreBundle\Service\BreadcrumbTrail;
 use SumoCoders\FrameworkCoreBundle\Service\Fallbacks;
 use SumoCoders\FrameworkCoreBundle\Service\PageTitle;
 use SumoCoders\FrameworkCoreBundle\Service\Security\NonceGenerator;
+use SumoCoders\FrameworkCoreBundle\Twig\AssetContentExtension;
 use SumoCoders\FrameworkCoreBundle\Twig\ContentExtension;
 use SumoCoders\FrameworkCoreBundle\Twig\FrameworkExtension;
-use SumoCoders\FrameworkCoreBundle\Twig\MailCssExtension;
 use SumoCoders\FrameworkCoreBundle\Twig\PaginatorExtension;
 use SumoCoders\FrameworkCoreBundle\Twig\PaginatorRuntime;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
@@ -114,7 +114,7 @@ return static function (ContainerConfigurator $container): void {
         ->set('framework.content_extension', ContentExtension::class)
         ->tag('twig.attribute_extension')
 
-        ->set('framework.mail_css_extension', MailCssExtension::class)
+        ->set('framework.asset_content_extension', AssetContentExtension::class)
         ->tag('twig.attribute_extension')
 
         /*

--- a/src/Twig/AssetContentExtension.php
+++ b/src/Twig/AssetContentExtension.php
@@ -5,16 +5,16 @@ namespace SumoCoders\FrameworkCoreBundle\Twig;
 use Symfony\Component\AssetMapper\AssetMapperInterface;
 use Twig\Attribute\AsTwigFunction;
 
-final readonly class MailCssExtension
+final readonly class AssetContentExtension
 {
     public function __construct(
         private AssetMapperInterface $assetMapper,
     ) {
     }
 
-    #[AsTwigFunction('mail_css', isSafe: ['html'])]
-    public function getMailCss(): string
+    #[AsTwigFunction('asset_content', isSafe: ['html'])]
+    public function getAssetContent(string $path): string
     {
-        return $this->assetMapper->getAsset('styles/mail.scss')->content;
+        return $this->assetMapper->getAsset($path)->content;
     }
 }

--- a/src/Twig/AssetContentExtension.php
+++ b/src/Twig/AssetContentExtension.php
@@ -2,6 +2,7 @@
 
 namespace SumoCoders\FrameworkCoreBundle\Twig;
 
+use Symfony\Component\Asset\Exception\AssetNotFoundException;
 use Symfony\Component\AssetMapper\AssetMapperInterface;
 use Twig\Attribute\AsTwigFunction;
 
@@ -13,8 +14,14 @@ final readonly class AssetContentExtension
     }
 
     #[AsTwigFunction('asset_content', isSafe: ['html'])]
-    public function getAssetContent(string $path): string
+    public function getAssetContent(string $path): ?string
     {
-        return $this->assetMapper->getAsset($path)->content;
+        $asset = $this->assetMapper->getAsset($path);
+
+        if ($asset === null) {
+            throw new AssetNotFoundException($path);
+        }
+
+        return $asset->content;
     }
 }

--- a/src/Twig/MailCssExtension.php
+++ b/src/Twig/MailCssExtension.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace SumoCoders\FrameworkCoreBundle\Twig;
+
+use Symfony\Component\AssetMapper\AssetMapperInterface;
+use Twig\Attribute\AsTwigFunction;
+
+final readonly class MailCssExtension
+{
+    public function __construct(
+        private AssetMapperInterface $assetMapper,
+    ) {
+    }
+
+    #[AsTwigFunction('mail_css', isSafe: ['html'])]
+    public function getMailCss(): string
+    {
+        return $this->assetMapper->getAsset('styles/mail.scss')->content;
+    }
+}

--- a/templates/Mail/base.html.twig
+++ b/templates/Mail/base.html.twig
@@ -1,4 +1,4 @@
-{% apply inky_to_html|inline_css(content('/../var/sass/mail.output.css')) %}
+{% apply inky_to_html|inline_css(mail_css()) %}
   <spacer size="16"></spacer>
   <container>
     <spacer size="16"></spacer>

--- a/templates/Mail/base.html.twig
+++ b/templates/Mail/base.html.twig
@@ -1,4 +1,4 @@
-{% apply inky_to_html|inline_css(mail_css()) %}
+{% apply inky_to_html|inline_css(asset_content('styles/mail.scss')) %}
   <spacer size="16"></spacer>
   <container>
     <spacer size="16"></spacer>


### PR DESCRIPTION
## Summary
- Add `MailCssExtension` exposing a `mail_css()` Twig function that reads the compiled `styles/mail.scss` asset through AssetMapper
- Use `mail_css()` in `Mail/base.html.twig` instead of referencing the compiled CSS file directly via `content('/../var/sass/mail.output.css')`
- Requires `symfony/asset-mapper: ^8.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Inline mail template CSS via AssetMapper-backed Twig function instead of a hardcoded compiled CSS file path.

New Features:
- Introduce a MailCss Twig extension exposing a mail_css() function to retrieve the compiled mail stylesheet via AssetMapper.

Enhancements:
- Register the MailCss Twig extension in the service container for use in mail templates.
- Update mail base template to use the mail_css() function for inlining styles rather than reading from a static filesystem path.

Build:
- Add symfony/asset-mapper as a runtime dependency to support asset-based CSS retrieval for mail templates.